### PR TITLE
Json jwe serilization and more

### DIFF
--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "56f1795190186ac5786bb83ae903f58b55f66c9c8d3e6470614a89e47f909786",
+  "originHash" : "4997482d4e77c96bc88442beae88ff106c9df9a77a0e4ea7b9096a8f0ad40884",
   "pins" : [
     {
       "identity" : "swiftformat",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "d6309f7440889427426143b4a0b100b959d3f3e6",
-        "version" : "0.54.3"
+        "revision" : "fb7ce2e469c18017c92523c93fd3b1b9757a4dd1",
+        "version" : "0.58.7"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "6c3d6c32a37224179dc290f21e03d1238f3d963b",
-        "version" : "0.56.2"
+        "revision" : "ecafb5b056cb7995324f0d310a61f30661d00cad",
+        "version" : "0.62.2"
       }
     }
   ],

--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -117,6 +117,13 @@
 		8A30B8FA22118FE6001834E3 /* JWECompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A30B8F922118FE6001834E3 /* JWECompressionTests.swift */; };
 		8A4B08B22213FF0600828536 /* Compressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4B08B12213FF0600828536 /* Compressor.swift */; };
 		8A5B190C2BF260F100A250EB /* AESGCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5B190B2BF260F100A250EB /* AESGCM.swift */; };
+		8B2F15062EE9D255006CC375 /* Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F15052EE9D254006CC375 /* Base64URL.swift */; };
+		8BB752042EEC4CC300BE39FF /* Recipient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB752032EEC4CC200BE39FF /* Recipient.swift */; };
+		8BB752062EEC4CD800BE39FF /* UnprotectedHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB752052EEC4CD600BE39FF /* UnprotectedHeader.swift */; };
+		8BB885B22EE33B2A00744297 /* JWEDecrypter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB885B12EE33B2600744297 /* JWEDecrypter.swift */; };
+		8BB885B42EE34A5300744297 /* MultiDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB885B32EE34A4C00744297 /* MultiDecryptor.swift */; };
+		8BB8DADF2EDF2A4F00634052 /* JWEObjectJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB8DADE2EDF2A4E00634052 /* JWEObjectJSON.swift */; };
+		8BB8DAE22EDF2A6E00634052 /* JWEObjectJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB8DAE12EDF2A6B00634052 /* JWEObjectJSONTests.swift */; };
 		9665A24722B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9665A24622B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift */; };
 		C803EFE51FA77E3000B71335 /* JWSRSATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C803EFE41FA77E3000B71335 /* JWSRSATests.swift */; };
 		C803EFE91FA7893A00B71335 /* JWSHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C803EFE81FA7893A00B71335 /* JWSHeaderTests.swift */; };
@@ -267,6 +274,13 @@
 		8A30B8F922118FE6001834E3 /* JWECompressionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWECompressionTests.swift; sourceTree = "<group>"; };
 		8A4B08B12213FF0600828536 /* Compressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compressor.swift; sourceTree = "<group>"; };
 		8A5B190B2BF260F100A250EB /* AESGCM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AESGCM.swift; sourceTree = "<group>"; };
+		8B2F15052EE9D254006CC375 /* Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64URL.swift; sourceTree = "<group>"; };
+		8BB752032EEC4CC200BE39FF /* Recipient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Recipient.swift; sourceTree = "<group>"; };
+		8BB752052EEC4CD600BE39FF /* UnprotectedHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnprotectedHeader.swift; sourceTree = "<group>"; };
+		8BB885B12EE33B2600744297 /* JWEDecrypter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWEDecrypter.swift; sourceTree = "<group>"; };
+		8BB885B32EE34A4C00744297 /* MultiDecryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiDecryptor.swift; sourceTree = "<group>"; };
+		8BB8DADE2EDF2A4E00634052 /* JWEObjectJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWEObjectJSON.swift; sourceTree = "<group>"; };
+		8BB8DAE12EDF2A6B00634052 /* JWEObjectJSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWEObjectJSONTests.swift; sourceTree = "<group>"; };
 		9665A24622B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ECAsn1IntegerConversionTests.swift; sourceTree = "<group>"; };
 		C803EFE41FA77E3000B71335 /* JWSRSATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWSRSATests.swift; sourceTree = "<group>"; };
 		C803EFE81FA7893A00B71335 /* JWSHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWSHeaderTests.swift; sourceTree = "<group>"; };
@@ -331,6 +345,7 @@
 		65125A2E1FBF6B9E007CF3AE /* JWE */ = {
 			isa = PBXGroup;
 			children = (
+				8BB8DAE12EDF2A6B00634052 /* JWEObjectJSONTests.swift */,
 				65869D432C7CE34700918E8B /* JWSCustomEncrypterDecrypterTests.swift */,
 				8A30B8F922118FE6001834E3 /* JWECompressionTests.swift */,
 				65676D8A1FC220C70031B26D /* JWEDeserializationTests.swift */,
@@ -386,6 +401,7 @@
 		653CECAD2C7DC6BF007A89E0 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				8B2F15052EE9D254006CC375 /* Base64URL.swift */,
 				65A77E931F7285A900A66DDE /* JOSEHeader.swift */,
 				65A7A1981F7295F5009449E7 /* Payload.swift */,
 				65353F5C1F750A6A003E099B /* DataExtensions.swift */,
@@ -453,10 +469,15 @@
 		653CECB42C7DC789007A89E0 /* JWE */ = {
 			isa = PBXGroup;
 			children = (
+				8BB752052EEC4CD600BE39FF /* UnprotectedHeader.swift */,
+				8BB885B12EE33B2600744297 /* JWEDecrypter.swift */,
+				8BB8DADE2EDF2A4E00634052 /* JWEObjectJSON.swift */,
+				8BB752032EEC4CC200BE39FF /* Recipient.swift */,
 				6533552D1F8FB61000A660C6 /* JWE.swift */,
 				653355291F8F6B6800A660C6 /* JWEHeader.swift */,
 				65617FCA1F90F8C700D8C743 /* Encrypter.swift */,
 				6572C2F11F96428800D4186D /* Decrypter.swift */,
+				8BB885B32EE34A4C00744297 /* MultiDecryptor.swift */,
 				653CECB62C7DC7C3007A89E0 /* KeyManagement */,
 				653CECBC2C7DC883007A89E0 /* ContentEncryption */,
 				8A30B8F622118FD0001834E3 /* Compression */,
@@ -969,6 +990,7 @@
 				652C613A1FD99A3300578E2A /* JWSSigningInputTest.swift in Sources */,
 				65869D442C7CE34700918E8B /* JWSCustomEncrypterDecrypterTests.swift in Sources */,
 				65E0346D2C7C6AA000C1E706 /* JWSCustomSignerVerifierTests.swift in Sources */,
+				8BB8DAE22EDF2A6E00634052 /* JWEObjectJSONTests.swift in Sources */,
 				C8A592401FC71586009CEFA6 /* RSADecryptionTests.swift in Sources */,
 				C803EFF31FA8A98F00B71335 /* DataExtensionTests.swift in Sources */,
 				653656072035D6C700A3AC3B /* JWKSetCollectionTests.swift in Sources */,
@@ -1036,6 +1058,7 @@
 			files = (
 				65617FCD1F90FB7600D8C743 /* RSAKeyEncryptionMode.swift in Sources */,
 				65617FCB1F90F8C700D8C743 /* Encrypter.swift in Sources */,
+				8BB752042EEC4CC300BE39FF /* Recipient.swift in Sources */,
 				65E733CC1FEBE8320009EAC6 /* JWKExtensions.swift in Sources */,
 				74BBAD6E2B2B070200ABEA95 /* PBES2.swift in Sources */,
 				396DD6DF257FB13C008353B9 /* ECKeyPair.swift in Sources */,
@@ -1052,6 +1075,7 @@
 				7402BE932626FC4A0012801E /* HMACSigner.swift in Sources */,
 				C8610F0B2029D21800859FCC /* RSA.swift in Sources */,
 				65F44EB31FE2E1C6000C5EA0 /* RSAKeys.swift in Sources */,
+				8BB885B42EE34A5300744297 /* MultiDecryptor.swift in Sources */,
 				652F6DE91F73E6780002DEE0 /* Serializer.swift in Sources */,
 				65A7A1991F7295F5009449E7 /* Payload.swift in Sources */,
 				657D0F7723FAE857004A7975 /* AESKeyWrappingMode.swift in Sources */,
@@ -1064,6 +1088,7 @@
 				65826AB22028696000AFFC46 /* RSAKeyCodable.swift in Sources */,
 				C8610F092029B15600859FCC /* Algorithms.swift in Sources */,
 				658EE1AF23F4067D00B6E967 /* AlgorithmExtensions.swift in Sources */,
+				8BB8DADF2EDF2A4F00634052 /* JWEObjectJSON.swift in Sources */,
 				65D8E8E820F499EF0059506A /* SymmetricKeys.swift in Sources */,
 				396DD6D5257FB0E8008353B9 /* ECKeyEncryption.swift in Sources */,
 				6558164423F44E8D00EA5FEC /* DirectEncryptionMode.swift in Sources */,
@@ -1077,14 +1102,17 @@
 				C85B1EF6204D82970026BDCB /* RSASigner.swift in Sources */,
 				65344C3E20F4CC9000FCBBA1 /* DataSymmetricKey.swift in Sources */,
 				65D868111F7CEBA200769BBF /* Verifier.swift in Sources */,
+				8BB752062EEC4CD800BE39FF /* UnprotectedHeader.swift in Sources */,
 				C86B876D203D857B00208387 /* JOSESwiftError.swift in Sources */,
 				65A77E941F7285A900A66DDE /* JOSEHeader.swift in Sources */,
 				6533552A1F8F6B6800A660C6 /* JWEHeader.swift in Sources */,
 				65353F5D1F750A6A003E099B /* DataExtensions.swift in Sources */,
 				65E733D11FEBF7960009EAC6 /* JWKParameters.swift in Sources */,
+				8BB885B22EE33B2A00744297 /* JWEDecrypter.swift in Sources */,
 				6582614D2029E98A00B594ED /* DataRSAPublicKey.swift in Sources */,
 				C81DBD581FFE66E700ECF69E /* AES.swift in Sources */,
 				74BBAD702B2B072900ABEA95 /* PBES2KeyEncryptionMode.swift in Sources */,
+				8B2F15062EE9D255006CC375 /* Base64URL.swift in Sources */,
 				C85B1EF2204D82640026BDCB /* JWS.swift in Sources */,
 				5FB760497BB7711EFB470B5A /* ECKeys.swift in Sources */,
 				6558165023F463C200EA5FEC /* AESCBCEncryption.swift in Sources */,

--- a/JOSESwift/Sources/Common/Base64URL.swift
+++ b/JOSESwift/Sources/Common/Base64URL.swift
@@ -1,0 +1,31 @@
+//
+//  Base64URL.swift
+//  JOSESwift
+//
+//  Created by Prem Eide on 10/12/2025.
+//
+
+import Foundation
+
+internal enum Base64URLError: Error {
+    case invalidBase64URLString
+}
+
+public struct Base64URL {
+    public let value: String
+
+    public init(_ base64URL: String) {
+        self.value = base64URL
+    }
+    
+    public init(_ data: Data) {
+        self.value = data.base64EncodedString()
+    }
+    
+    public func decode() throws -> Data {
+        guard let data = Data(base64URLEncoded: value) else {
+            throw Base64URLError.invalidBase64URLString
+        }
+        return data
+    }
+}

--- a/JOSESwift/Sources/JWE/JWEDecrypter.swift
+++ b/JOSESwift/Sources/JWE/JWEDecrypter.swift
@@ -1,0 +1,20 @@
+//
+//  JWEDecrypter.swift
+//  JOSESwift
+//
+//  Created by Prem Eide on 05/12/2025.
+//
+
+import Foundation
+public protocol JWEDecrypter {
+    func decrypt(_ context: DecryptionContext) throws -> Data
+}
+
+public struct DecryptionContext {
+    let header: JWEHeader
+    let encryptedKey: Base64URL
+    let initializationVector: Base64URL
+    let ciphertext: Base64URL
+    let authenticationTag: Base64URL
+    let aad: Data
+}

--- a/JOSESwift/Sources/JWE/JWEObjectJSON.swift
+++ b/JOSESwift/Sources/JWE/JWEObjectJSON.swift
@@ -1,0 +1,122 @@
+//
+//  JWEObjectJSON.swift
+//  JOSESwift
+//
+//  Created by Prem Eide on 02/12/2025.
+//
+
+import Foundation
+
+/// JSON Web Encryption (JWE) secured object with JSON serialisation
+/// https://www.rfc-editor.org/rfc/rfc7516#section-7.2
+public struct JWEObjectJSON {
+    
+    /// The integrity-protected shared header
+    public let protected: JWEHeader
+    
+    /// The recipients list.
+    public let recipients: [Recipient]
+    
+    /// The initialisation vector
+    public let iv: Base64URL
+    
+    /// The cipher text
+    public let cipherText: Base64URL
+    
+    /// The authentication tag
+    public let tag: Base64URL
+    
+    /// The additional authenticated data
+    public var aad: Data { // FIXME: Not always correct. See section-5.1 point 14.
+        protected.data().base64URLEncodedData()
+    }
+    
+    /// Creates a `JWEObjectJSON` by parsing the given JWE JSON serialization string.
+    public init(jsonString: String) throws {
+        let raw = try Self.parseJSONObject(jsonString)
+        
+        self.protected  = try Self.parseProtectedHeader(from: raw)
+        self.cipherText = try Self.getBase64URL(forKey: "ciphertext", in: raw)
+        self.iv         = try Self.getBase64URL(forKey: "iv", in: raw)
+        self.tag        = try Self.getBase64URL(forKey: "tag", in: raw)
+        self.recipients = try Self.parseRecipients(from: raw)
+    }
+    
+    public func decrypt(using decrypter: JWEDecrypter) throws -> Payload {
+        let context = DecryptionContext(
+            header: protected,
+            encryptedKey: try getEncryptedKey(),
+            initializationVector: iv,
+            ciphertext: cipherText,
+            authenticationTag: tag,
+            aad: aad
+        )
+        let decryptedData = try decrypter.decrypt(context)
+        return Payload(decryptedData)
+    }
+    
+    private func getEncryptedKey() throws -> Base64URL {
+        if recipients.count == 1 {
+            return recipients[0].encryptedKey
+        }
+        let recipientsList = recipients.map { $0.toJSONObject() }
+        let recipientsMap = ["recipients": recipientsList]
+        let jsonData = try JSONSerialization.data(withJSONObject: recipientsMap)
+        return Base64URL(jsonData)
+    }
+}
+
+extension JWEObjectJSON {
+    
+    static func parseJSONObject(_ jsonString: String) throws -> [String: Any] {
+        let data = Data(jsonString.utf8)
+        return try parseJSONObject(data)
+    }
+    
+    static func parseJSONObject(_ jsonData: Data) throws -> [String: Any] {
+        guard let raw = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+            throw JWEObjectJSONError.invalidJSON
+        }
+        return raw
+    }
+    
+    static func getBase64URL(forKey key: String, in raw: [String: Any]) throws -> Base64URL {
+        guard let string = raw[key] as? String else {
+            throw JWEObjectJSONError.missingField(key)
+        }
+        return Base64URL(string)
+    }
+    
+    static func parseProtectedHeader(from raw: [String: Any]) throws -> JWEHeader {
+        let protectedData = try getBase64URL(forKey: "protected", in: raw).decode()
+        let headerAny = try JSONSerialization.jsonObject(with: protectedData)
+        
+        guard let headerParams = headerAny as? [String: Any] else {
+            throw JWEObjectJSONError.invalidJSON
+        }
+        return try JWEHeader(parameters: headerParams)
+    }
+    
+    static func parseRecipients(from raw: [String: Any]) throws -> [Recipient] {
+        if let recipientsArray = raw["recipients"] as? [[String: Any]] {
+            // General serialization
+            return try recipientsArray.map { recipientJSON in
+                guard let headerJSON = recipientJSON["header"] as? [String: Any] else {
+                    throw JWEObjectJSONError.invalidJSON
+                }
+                let recipientHeader = UnprotectedHeader(parameters: headerJSON)
+                let encryptedKey = try getBase64URL(forKey: "encrypted_key", in: recipientJSON)
+                return Recipient(unprotectedHeader: recipientHeader, encryptedKey: encryptedKey)
+            }
+        } else {
+            // Flattened serialization
+            let encryptedKey = try getBase64URL(forKey: "encrypted_key", in: raw)
+            return [Recipient(unprotectedHeader: nil, encryptedKey: encryptedKey)]
+        }
+    }
+}
+
+enum JWEObjectJSONError: Error {
+    case invalidJSON
+    case missingField(String)
+}

--- a/JOSESwift/Sources/JWE/KeyManagement/KeyManagementMode.swift
+++ b/JOSESwift/Sources/JWE/KeyManagement/KeyManagementMode.swift
@@ -131,7 +131,7 @@ extension KeyManagementAlgorithm {
 
             return DirectEncryptionMode(keyManagementAlgorithm: self, sharedSymmetricKey: sharedSymmetricKey)
         case .ECDH_ES, .ECDH_ES_A128KW, .ECDH_ES_A192KW, .ECDH_ES_A256KW:
-            guard let recipientPrivateKey = cast(decryptionKey, to: ECKeyEncryption.PrivateKey.self) else {
+            guard let recipientPrivateKey = decryptionKey as? ECKeyEncryption.PrivateKey else {
                 return nil
             }
 

--- a/JOSESwift/Sources/JWE/MultiDecryptor.swift
+++ b/JOSESwift/Sources/JWE/MultiDecryptor.swift
@@ -1,0 +1,69 @@
+//
+//  MultiDecryptor.swift
+//  JOSESwift
+//
+//  Created by Prem Eide on 05/12/2025.
+//
+
+import Foundation
+
+public struct MultiDecryptor: JWEDecrypter {
+    private let jwk: JWK
+    
+    public init(jwk: JWK) {
+        self.jwk = jwk
+    }
+    
+    public func decrypt(_ context: DecryptionContext) throws -> Data {
+        let recipients = try getRecipients(from: context)
+        let expectedKid = try jwk.thumbprint()
+        
+        guard let recipient = recipients.first(where: { $0.unprotectedHeader?.keyID == expectedKid }) else {
+            throw MultiDecryptorError.recipientNotFound
+        }
+        guard let recipientHeader = recipient.unprotectedHeader else {
+            throw MultiDecryptorError.missingRecipientHeader
+        }
+        
+        let joinedHeader = try context.header.join(recipientHeader)
+        
+        let newContext = DecryptionContext(
+            header: joinedHeader,
+            encryptedKey: recipient.encryptedKey,
+            initializationVector: context.initializationVector,
+            ciphertext: context.ciphertext,
+            authenticationTag: context.authenticationTag,
+            aad: context.aad
+        )
+        
+        guard let keyAlg = recipientHeader.alg else {
+            throw MultiDecryptorError.missingKeyManagementAlgorithm
+        }
+        guard let contentAlg = joinedHeader.contentEncryptionAlgorithm else {
+            throw MultiDecryptorError.missingContentEncryptionAlgorithm
+        }
+        
+        guard let decrypter = Decrypter(
+            keyManagementAlgorithm: keyAlg,
+            contentEncryptionAlgorithm: contentAlg,
+            decryptionKey: jwk
+        ) else {
+            throw MultiDecryptorError.couldNotCreateDecrypter
+        }
+        return try decrypter.decrypt(newContext)
+    }
+    
+    private func getRecipients(from context: DecryptionContext) throws -> [Recipient] {
+        let recipientsData = try context.encryptedKey.decode()
+        let jsonObject = try JWEObjectJSON.parseJSONObject(recipientsData)
+        return try JWEObjectJSON.parseRecipients(from: jsonObject)
+    }
+}
+
+internal enum MultiDecryptorError: Error {
+    case recipientNotFound
+    case missingRecipientHeader
+    case missingKeyManagementAlgorithm
+    case missingContentEncryptionAlgorithm
+    case couldNotCreateDecrypter
+}

--- a/JOSESwift/Sources/JWE/Recipient.swift
+++ b/JOSESwift/Sources/JWE/Recipient.swift
@@ -1,0 +1,30 @@
+//
+//  Recipient.swift
+//  JOSESwift
+//
+//  Created by Prem Eide on 12/12/2025.
+//
+
+/// Individual recipient in a JWE object serialisable to JSON
+public struct Recipient {
+    /// The per-recipient unprotected header
+    public let unprotectedHeader: UnprotectedHeader?
+    /// The encrypted key
+    public let encryptedKey: Base64URL
+    
+    public init(unprotectedHeader: UnprotectedHeader?, encryptedKey: Base64URL) {
+        self.unprotectedHeader = unprotectedHeader
+        self.encryptedKey = encryptedKey
+    }
+    
+    /// Turn into a JSON object that matches JWE JSON Serialization
+    public func toJSONObject() -> [String: Any] {
+        var json: [String: Any] = ["encrypted_key": encryptedKey.value]
+        
+        if let header = unprotectedHeader {
+            json["header"] = header.parameters
+        }
+        
+        return json
+    }
+}

--- a/JOSESwift/Sources/JWE/UnprotectedHeader.swift
+++ b/JOSESwift/Sources/JWE/UnprotectedHeader.swift
@@ -1,0 +1,23 @@
+//
+//  UnprotectedHeader.swift
+//  JOSESwift
+//
+//  Created by Prem Eide on 12/12/2025.
+//
+
+public struct UnprotectedHeader {
+    public var parameters: [String: Any]
+    
+    public init(parameters: [String: Any]) {
+        self.parameters = parameters
+    }
+    
+    public var keyID: String? {
+        parameters["kid"] as? String
+    }
+    
+    public var alg: KeyManagementAlgorithm? {
+        guard let algStr = parameters["alg"] as? String else { return nil }
+        return KeyManagementAlgorithm(rawValue: algStr)
+    }
+}

--- a/JOSESwift/Sources/JWK/EC/DataECPrivateKey.swift
+++ b/JOSESwift/Sources/JWK/EC/DataECPrivateKey.swift
@@ -27,7 +27,7 @@ extension Data: ExpressibleAsECPrivateKeyComponents {
     public static func representing(ecPrivateKeyComponents components: ECPrivateKeyComponents) throws -> Data {
         let xBytes = [UInt8](components.x)
         let yBytes = [UInt8](components.y)
-        let dBytes = [UInt8](components.d)
+        let dBytes = [UInt8](components.d!)
         let uncompressedIndication: [UInt8] = [ECCompression.Uncompressed.rawValue]
 
         guard
@@ -58,6 +58,6 @@ extension Data: ExpressibleAsECPrivateKeyComponents {
         let xData = Data(xBytes)
         let yData = Data(yBytes)
         let dData = Data(dBytes)
-        return (curve.rawValue, xData, yData, dData)
+        return (curve.rawValue, xData, yData, dData, nil)
     }
 }

--- a/JOSESwift/Sources/JWK/EC/ECKeyCodable.swift
+++ b/JOSESwift/Sources/JWK/EC/ECKeyCodable.swift
@@ -102,7 +102,7 @@ extension ECPrivateKey: Encodable {
         try ecParameters.encode(crv, forKey: .curve)
         try ecParameters.encode(x, forKey: .x)
         try ecParameters.encode(y, forKey: .y)
-        try ecParameters.encode(privateKey, forKey: .privateKey)
+        try ecParameters.encode(d, forKey: .d)
     }
 }
 
@@ -132,13 +132,14 @@ extension ECPrivateKey: Decodable {
         let crv = try ecParameters.decode(ECCurveType.self, forKey: .curve)
         let x = try ecParameters.decode(String.self, forKey: .x)
         let y = try ecParameters.decode(String.self, forKey: .y)
-        let privateKey = try ecParameters.decode(String.self, forKey: .privateKey)
+        let d = try ecParameters.decode(String.self, forKey: .d)
 
         try self.init(
                 crv: crv.rawValue,
                 x: x,
                 y: y,
-                privateKey: privateKey,
+                d: d,
+                privateKeyHandle: nil,
                 additionalParameters: parameters
         )
     }

--- a/JOSESwift/Sources/JWK/EC/ECKeyPair.swift
+++ b/JOSESwift/Sources/JWK/EC/ECKeyPair.swift
@@ -44,7 +44,7 @@ public extension ECKeyPair {
 public extension ECPrivateKey {
 
     func getPublic() -> ECPublicKey {
-        let parametersForPublic = parameters.filter { $0.key != ECParameter.privateKey.rawValue }
+        let parametersForPublic = parameters.filter { $0.key != ECParameter.d.rawValue }
         return ECPublicKey(crv: crv, x: x, y: y, additionalParameters: parametersForPublic)
     }
 

--- a/JOSESwift/Sources/JWK/JWKParameters.swift
+++ b/JOSESwift/Sources/JWK/JWKParameters.swift
@@ -63,5 +63,5 @@ public enum ECParameter: String, CodingKey {
     case curve = "crv"
     case x = "x"
     case y = "y"
-    case privateKey = "d"
+    case d = "d"
 }

--- a/Tests/DataECPrivateKeyTests.swift
+++ b/Tests/DataECPrivateKeyTests.swift
@@ -44,11 +44,12 @@ class DataECPrivateKeyTests: ECCryptoTestCase {
 
     func testDataFromPrivateKeyComponents() {
         allTestData.forEach { testData in
-            let components = (
+            let components = ECPrivateKeyComponents(
                     testData.expectedCurveType,
                     testData.expectedXCoordinate,
                     testData.expectedYCoordinate,
-                    testData.expectedPrivateOctetString
+                    testData.expectedPrivateOctetString,
+                    nil
             )
             let data = try! Data.representing(ecPrivateKeyComponents: components)
             XCTAssertEqual(data, testData.privateKeyData)
@@ -98,11 +99,12 @@ class DataECPrivateKeyTests: ECCryptoTestCase {
             default: XCTFail("Unexpected error: \(error)")
             }
         }
-        let components = (
+        let components = ECPrivateKeyComponents(
                 p256.expectedCurveType,
                 p256.expectedXCoordinate,
                 p256.expectedYCoordinate,
-                p256.expectedPrivateOctetString.dropLast()
+                p256.expectedPrivateOctetString.dropLast(),
+                nil
         )
         XCTAssertThrowsError(
                 try Data.representing(ecPrivateKeyComponents: components),

--- a/Tests/ECPrivateKeyToDataTests.swift
+++ b/Tests/ECPrivateKeyToDataTests.swift
@@ -32,7 +32,7 @@ class ECPrivateKeyToDataTests: ECCryptoTestCase {
                     crv: testData.expectedCurveType,
                     x: testData.expectedXCoordinateBase64Url,
                     y: testData.expectedYCoordinateBase64Url,
-                    privateKey: testData.expectedPrivateBase64Url
+                    d: testData.expectedPrivateBase64Url
             )
             let data = try! jwk.converted(to: Data.self)
 

--- a/Tests/ECPrivateKeyToSecKeyTests.swift
+++ b/Tests/ECPrivateKeyToSecKeyTests.swift
@@ -33,7 +33,7 @@ class ECPrivateKeyToSecKeyTests: ECCryptoTestCase {
                     crv: testData.expectedCurveType,
                     x: testData.expectedXCoordinateBase64Url,
                     y: testData.expectedYCoordinateBase64Url,
-                    privateKey: testData.expectedPrivateBase64Url
+                    d: testData.expectedPrivateBase64Url
             )
             let key = try! jwk.converted(to: SecKey.self)
 
@@ -46,20 +46,20 @@ class ECPrivateKeyToSecKeyTests: ECCryptoTestCase {
             let crv = testData.expectedCurveType
             let x = testData.expectedXCoordinateBase64Url
             let y = testData.expectedYCoordinateBase64Url
-            let privateKey = testData.expectedPrivateBase64Url
+            let d = testData.expectedPrivateBase64Url
             let invalid = "\u{96}"
-            checkInvalidArgumentListForException(crv: "P-INVALID", x: x, y: y, privateKey: privateKey)
-            checkInvalidArgumentListForException(crv: crv, x: invalid, y: y, privateKey: privateKey)
-            checkInvalidArgumentListForException(crv: crv, x: x, y: invalid, privateKey: privateKey)
-            checkInvalidArgumentListForException(crv: crv, x: x, y: y, privateKey: invalid)
+            checkInvalidArgumentListForException(crv: "P-INVALID", x: x, y: y, d: d)
+            checkInvalidArgumentListForException(crv: crv, x: invalid, y: y, d: d)
+            checkInvalidArgumentListForException(crv: crv, x: x, y: invalid, d: d)
+            checkInvalidArgumentListForException(crv: crv, x: x, y: y, d: invalid)
         }
     }
 
     // MARK: Helper functions
 
-    func checkInvalidArgumentListForException(crv: String, x: String, y: String, privateKey: String) {
+    func checkInvalidArgumentListForException(crv: String, x: String, y: String, d: String) {
         let closure = {
-            let jwk = try ECPrivateKey(crv: crv, x: x, y: y, privateKey: privateKey)
+            let jwk = try ECPrivateKey(crv: crv, x: x, y: y, d: d)
             _ = try jwk.converted(to: SecKey.self)
         }
         XCTAssertThrowsError(try closure())

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -223,32 +223,6 @@ class JWEHeaderTests: XCTestCase {
         XCTFail()
     }
 
-    func testInitDirectlyWithMissingRequiredAlgParameter() {
-        do {
-            _ = try JWEHeader(parameters: ["enc": "something"], headerData: try! JSONSerialization.data(withJSONObject: ["enc": "something"], options: []))
-        } catch HeaderParsingError.requiredHeaderParameterMissing(let parameter) {
-            XCTAssertEqual(parameter, "alg")
-            return
-        } catch {
-            XCTFail()
-        }
-
-        XCTFail()
-    }
-
-    func testInitWithMissingRequiredAlgParameter() {
-        do {
-            _ = try JWEHeader(parameters: ["enc": "something"])
-        } catch HeaderParsingError.requiredHeaderParameterMissing(let parameter) {
-            XCTAssertEqual(parameter, "alg")
-            return
-        } catch {
-            XCTFail()
-        }
-
-        XCTFail()
-    }
-
     func testInitWithInvalidJSONDictionary() {
         do {
             _ = try JWEHeader(parameters: ["typ": JOSEDeserializer()], headerData: Data())

--- a/Tests/JWEObjectJSONTests.swift
+++ b/Tests/JWEObjectJSONTests.swift
@@ -1,0 +1,121 @@
+//
+//  JWEObjectJSONTests.swift
+//  JOSESwift
+//
+//  Created by Prem Eide on 02/12/2025.
+//
+
+
+import XCTest
+@testable import JOSESwift
+
+final class JWEObjectJSONTests: ECCryptoTestCase {
+    
+    private let GENERAL_JSON_JWE_COMBINED = """
+    {
+        "ciphertext": "cBE1WhgQcg9iA1pcYe6hCO8XdqJ_ZGReEAOeqw9iJaHhQsMzvWlD_ErX5KOd5hI0wZvc",
+        "protected": "eyJ0eXAiOiJKV0UiLCJlbmMiOiJBMjU2R0NNIn0",
+        "recipients": [
+            {
+                "encrypted_key": "TnBh1cV3P8sbqnWoajeeuyBQf9oNiOp2hPxxprO6mLepq1zt0V-Jed2P5-ZAYpOq5JaPKn7egvfs0uuMsFAL4xt7EgSZfYHuXUHMZRNVATrmoXR70bXCH9__vMtSYBrceVWSJSwF01TaNGwPrwetu2hvGO7YVXF5wDjJKB-cnJ5M4U3em0cNoSM986VgyZG3ArztxmKiWs3TX8u03QkUNTG0lWjFHEvHwLt9tGJMoiwx4tfh5Q0OcuxcA1xFYeOy9JsP2LNe6rCKjgA396np5us22-coqABttwY8kA78wTsr4YEus8NyhogaCV6aJ-S-NnhNMISkUlnU-kmnX3WDZA",
+                "header": {
+                    "alg": "RSA-OAEP-256",
+                    "kid": "rsa1"
+                }
+            },
+            {
+                "encrypted_key": "fDP0iySx6SnQao0xegMesiNq3v5GrVgTax5sh3Y6TMV5LX1YMXRLhg",
+                "header": {
+                    "epk": {
+                        "kty": "EC",
+                        "crv": "P-256",
+                        "x": "x7b6-aldF4veusN1YlK1kHv1m8xUp2BxPG3rcrMyY2U",
+                        "y": "CESJcKwPhK4Il8hAVSNke8wq6SbHqY_BCWuIkntk5Bk"
+                    },
+                    "alg": "ECDH-ES+A256KW",
+                    "kid": "ec1"
+                }
+            }
+        ],
+        "tag": "bUky-v6rh_Ge7_CFMQOTuw",
+        "iv": "GdKaxFnxvcWweY-X"
+    }
+    """
+    
+    private let GENERAL_JSON_JWE_EC = """
+    {
+        "ciphertext": "OiouIje2Yrec1J9Whw",
+        "protected": "eyJlbmMiOiJBMTI4R0NNIn0",
+        "recipients": [
+            {
+                "encrypted_key": "_g0qbd2s-JmouR6gJcm5yQHdjHnwljuT",
+                "header": {
+                    "alg": "ECDH-ES+A128KW",
+                    "kid": "y0kvfqkdTR5eYPsd6u0ncuqmG7fF72Z-ty2c0S1wzvc"
+                }
+            },
+            {
+                "encrypted_key": "Go0AE2zNKwvgMaJcOF2sGFrPk-8mM_ll",
+                "header": {
+                    "alg": "ECDH-ES+A128KW",
+                    "kid": "wSgBepPu4b3vdNc2rpTGkQQ8UZw3ZF7lfWrpCEz51Uw"
+                }
+            }
+        ],
+        "tag": "XWIuEs_QKfD5vtRlN9LNVA",
+        "iv": "-K7qUpvoKT0SIcFi"
+    }
+    """
+    
+    func testParsingGeneralJsonJweCombined() throws {
+        let jwe = try JWEObjectJSON(jsonString: GENERAL_JSON_JWE_COMBINED)
+        
+        XCTAssertEqual(jwe.recipients.count, 2)
+        XCTAssertEqual(jwe.cipherText.value, "cBE1WhgQcg9iA1pcYe6hCO8XdqJ_ZGReEAOeqw9iJaHhQsMzvWlD_ErX5KOd5hI0wZvc")
+        XCTAssertEqual(jwe.iv.value, "GdKaxFnxvcWweY-X")
+        XCTAssertEqual(jwe.tag.value, "bUky-v6rh_Ge7_CFMQOTuw")
+        
+        XCTAssertEqual(jwe.protected.parameters["enc"] as? String, "A256GCM")
+        
+        XCTAssertEqual(jwe.recipients[0].unprotectedHeader?.alg as? String, "RSA-OAEP-256")
+        XCTAssertEqual(jwe.recipients[1].unprotectedHeader?.alg as? String, "ECDH-ES+A256KW")
+    }
+    
+    func testParsingGeneralJsonJweEC() throws {
+        let jwe = try JWEObjectJSON(jsonString: GENERAL_JSON_JWE_EC)
+        
+        XCTAssertEqual(jwe.recipients.count, 2)
+        XCTAssertEqual(jwe.cipherText.value, "OiouIje2Yrec1J9Whw")
+        XCTAssertEqual(jwe.iv.value, "-K7qUpvoKT0SIcFi")
+        XCTAssertEqual(jwe.tag.value, "XWIuEs_QKfD5vtRlN9LNVA")
+        
+        XCTAssertEqual(jwe.protected.parameters["enc"] as? String, "A128GCM")
+        
+        XCTAssertEqual(jwe.recipients[0].unprotectedHeader?.alg as? String, "ECDH-ES+A128KW")
+        XCTAssertEqual(jwe.recipients[1].unprotectedHeader?.alg as? String, "ECDH-ES+A128KW")
+    }
+    
+    func testJoiningHeaders() throws {
+        let jwe = try JWEObjectJSON(jsonString: GENERAL_JSON_JWE_EC)
+        
+        let recipientHeader = try XCTUnwrap(jwe.recipients.first?.unprotectedHeader)
+        let joined = try jwe.protected.join(recipientHeader)
+        
+        XCTAssertEqual(joined.parameters["enc"] as? String, "A128GCM")
+        XCTAssertEqual(joined.parameters["alg"] as? String, "ECDH-ES+A128KW")
+        XCTAssertEqual(joined.parameters["kid"] as? String, "y0kvfqkdTR5eYPsd6u0ncuqmG7fF72Z-ty2c0S1wzvc")
+    }
+    
+    func testJoiningHeadersCollisionThrows() throws {
+        let jwe = try JWEObjectJSON(jsonString: GENERAL_JSON_JWE_EC)
+        
+        let collidingHeader = UnprotectedHeader(parameters: [
+            "enc": "A256GCM"
+        ])
+        
+        XCTAssertThrowsError(
+            try jwe.protected.join(collidingHeader),
+            "Expected join to throw on header collision"
+        )
+    }
+}

--- a/Tests/JWKECDecodingTests.swift
+++ b/Tests/JWKECDecodingTests.swift
@@ -136,7 +136,7 @@ class JWKECDecodingTests: ECCryptoTestCase {
 
         XCTAssertNotNil(jwk)
         checkSharedKeyComponents(jwk: jwk!)
-        XCTAssertEqual(jwk?.privateKey, Consts.keyD)
+        XCTAssertEqual(jwk?.d, Consts.keyD)
     }
 
     func testDecodingPrivateKey() {
@@ -144,7 +144,7 @@ class JWKECDecodingTests: ECCryptoTestCase {
 
         XCTAssertNotNil(jwk)
         checkSharedKeyComponents(jwk: jwk!)
-        XCTAssertEqual(jwk?.privateKey, Consts.keyD)
+        XCTAssertEqual(jwk?.d, Consts.keyD)
     }
 
     func testDecodingPrivateKeyMissingKeyType() {
@@ -195,7 +195,7 @@ class JWKECDecodingTests: ECCryptoTestCase {
             Consts.innerKeyJSONX,
             Consts.innerKeyJSONY
         ])
-        checkMissingKeyPrivate(json: privateKeyJSONMissingPrivateKey, key: ECParameter.privateKey.rawValue)
+        checkMissingKeyPrivate(json: privateKeyJSONMissingPrivateKey, key: ECParameter.d.rawValue)
     }
 
     func testDecodingPrivateKeyWrongDataFormat() {

--- a/Tests/JWKECEncodingTests.swift
+++ b/Tests/JWKECEncodingTests.swift
@@ -67,7 +67,7 @@ class JWKECEncodingTests: ECCryptoTestCase {
                     crv: keyData.expectedCurveType,
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url,
-                    privateKey: keyData.expectedPrivateBase64Url,
+                    d: keyData.expectedPrivateBase64Url,
                     additionalParameters: ["alg": keyData.signatureAlgorithm, "kid": Consts.kid]
             )
 
@@ -85,7 +85,7 @@ class JWKECEncodingTests: ECCryptoTestCase {
                     crv: keyData.expectedCurveType,
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url,
-                    privateKey: keyData.expectedPrivateBase64Url,
+                    d: keyData.expectedPrivateBase64Url,
                     additionalParameters: ["alg": keyData.signatureAlgorithm, "kid": Consts.kid, "breeze": "through"]
             )
 

--- a/Tests/JWKECKeysTests.swift
+++ b/Tests/JWKECKeysTests.swift
@@ -42,7 +42,7 @@ class JWKECKeysTests: ECCryptoTestCase {
                     crv: keyData.expectedCurveType,
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url,
-                    privateKey: keyData.expectedPrivateBase64Url,
+                    d: keyData.expectedPrivateBase64Url,
                     additionalParameters: [ "kty": "wrongKty" ]
             )
 
@@ -82,7 +82,7 @@ class JWKECKeysTests: ECCryptoTestCase {
                     crv: keyData.expectedCurveType,
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url,
-                    privateKey: keyData.expectedPrivateBase64Url
+                    d: keyData.expectedPrivateBase64Url
             )
 
             XCTAssertEqual(key.keyType, .EC)
@@ -97,7 +97,7 @@ class JWKECKeysTests: ECCryptoTestCase {
             XCTAssertEqual(key.y, keyData.expectedYCoordinateBase64Url)
             XCTAssertEqual(key["y"] ?? "", keyData.expectedYCoordinateBase64Url)
 
-            XCTAssertEqual(key.privateKey, keyData.expectedPrivateBase64Url)
+            XCTAssertEqual(key.d, keyData.expectedPrivateBase64Url)
             XCTAssertEqual(key["d"] ?? "", keyData.expectedPrivateBase64Url)
 
             // kty, crv, x, y, d
@@ -121,7 +121,7 @@ class JWKECKeysTests: ECCryptoTestCase {
                     crv: keyData.expectedCurveType,
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url,
-                    privateKey: keyData.expectedPrivateBase64Url
+                    d: keyData.expectedPrivateBase64Url
             )
 
             XCTAssertEqual(jwk.keyType, .EC)
@@ -155,7 +155,7 @@ class JWKECKeysTests: ECCryptoTestCase {
                     crv: keyData.expectedCurveType,
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url,
-                    privateKey: keyData.expectedPrivateBase64Url,
+                    d: keyData.expectedPrivateBase64Url,
                     additionalParameters: params
             )
 
@@ -165,7 +165,7 @@ class JWKECKeysTests: ECCryptoTestCase {
 
     func testInvalidPrivateCurveType() {
         do {
-            _ = try ECPrivateKey(crv: "P-255", x: "", y: "", privateKey: "")
+            _ = try ECPrivateKey(crv: "P-255", x: "", y: "", d: "")
         } catch JOSESwiftError.invalidCurvePointOctetLength {
             return
         } catch {
@@ -195,7 +195,7 @@ class JWKECKeysTests: ECCryptoTestCase {
                     crv: keyData.expectedCurveType,
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url,
-                    privateKey: keyData.expectedPrivateBase64Url
+                    d: keyData.expectedPrivateBase64Url
             )
 
             XCTAssertEqual(try? key.thumbprint(), keyData.expectedThumbprint)
@@ -238,7 +238,7 @@ class JWKECKeysTests: ECCryptoTestCase {
                     crv: keyData.expectedCurveType,
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url,
-                    privateKey: keyData.expectedPrivateBase64Url
+                    d: keyData.expectedPrivateBase64Url
             ).withThumbprintAsKeyId()
 
             XCTAssertEqual(key.parameters[JWKParameter.keyIdentifier.rawValue], keyData.expectedThumbprint)
@@ -253,7 +253,7 @@ class JWKECKeysTests: ECCryptoTestCase {
                     crv: keyData.expectedCurveType,
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url,
-                    privateKey: keyData.expectedPrivateBase64Url,
+                    d: keyData.expectedPrivateBase64Url,
                     additionalParameters: [JWKParameter.keyUse.rawValue: useKey]
             ).withThumbprintAsKeyId()
 

--- a/Tests/SecKeyECPrivateKeyTests.swift
+++ b/Tests/SecKeyECPrivateKeyTests.swift
@@ -52,17 +52,18 @@ class SecKeyECPrivateKeyTests: ECCryptoTestCase {
             XCTAssertEqual(jwk?.crv.rawValue, testData.expectedCurveType)
             XCTAssertEqual(jwk?.x, testData.expectedXCoordinateBase64Url)
             XCTAssertEqual(jwk?.y, testData.expectedYCoordinateBase64Url)
-            XCTAssertEqual(jwk?.privateKey, testData.expectedPrivateBase64Url)
+            XCTAssertEqual(jwk?.d, testData.expectedPrivateBase64Url)
         }
     }
 
     func testPrivateKeyFromPrivateComponents() throws {
         try allTestData.forEach { testData in
-            let components = (
+            let components = ECPrivateKeyComponents(
                     testData.expectedCurveType,
                     testData.expectedXCoordinate,
                     testData.expectedYCoordinate,
-                    testData.expectedPrivateOctetString
+                    testData.expectedPrivateOctetString,
+                    nil
             )
             let secKey = try SecKey.representing(ecPrivateKeyComponents: components)
 
@@ -74,7 +75,7 @@ class SecKeyECPrivateKeyTests: ECCryptoTestCase {
     }
 
     func testPrivateKeyFromInvalidCurveType() {
-        let components = ("P-Invalid", p256.expectedXCoordinate, p256.expectedYCoordinate, p256.expectedPrivateOctetString)
+        let components = ECPrivateKeyComponents("P-Invalid", p256.expectedXCoordinate, p256.expectedYCoordinate, p256.expectedPrivateOctetString, nil)
         XCTAssertThrowsError(try SecKey.representing(ecPrivateKeyComponents: components)) { error in
             XCTAssertEqual(error as? JWKError, JWKError.invalidECCurveType)
         }


### PR DESCRIPTION
Fixes:

* Support for parsing General JWE JSON Serialization Syntax https://datatracker.ietf.org/doc/html/rfc7516#section-7.2.1
* Support for using hardware backed private keys: 
  * ECPrivateKey (JWK) can be initialised and decrypt using Secure Enclave key, where private key is non-exportable. 
  * 'd' component is therefore optional and new field 'privateKeyHandle' is the referance to SecureEnclave-key (insipired by nimbus' implementation of this)
* Support for decrypting multi-recipient JWEs ([A.4.7](https://datatracker.ietf.org/doc/html/rfc7516#appendix-A.4.7).):
 * 

